### PR TITLE
Fixes checkbox and radio labels with only whitespace 

### DIFF
--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -3,6 +3,10 @@
 
   &:not(.euiCheckbox--noLabel) .euiCheckbox__input {
     @include euiScreenReaderOnly;
+    // Because this input is still focusable, it causes the screen-reader outline
+    // to extend to the position of the screen-reader element.
+    // So we must position it against it's own bounds.
+    left: 0;
   }
 
   .euiCheckbox__input {
@@ -11,7 +15,7 @@
       padding-left: ($euiCheckBoxSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
-      min-height: $euiFontSizeS; // In case the label is just white space
+      min-height: $euiCheckBoxSize; // In case the label is just white space
       position: relative;
       z-index: 2;
       cursor: pointer;
@@ -64,8 +68,7 @@
       }
     }
 
-    &:focus,
-    &:active:not(:disabled) {
+    &:focus {
       + .euiCheckbox__square {
         @include euiCustomControlFocused;
       }

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -94,6 +94,7 @@
       z-index: 1; /* 1 */
       margin: 0; /* 1 */
       cursor: pointer;
+      outline: none;
     }
   }
 }

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -11,6 +11,7 @@
       padding-left: ($euiCheckBoxSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
+      min-height: $euiFontSizeS; // In case the label is just white space
       position: relative;
       z-index: 2;
       cursor: pointer;

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -11,6 +11,7 @@
       padding-left: ($euiRadioSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
+      min-height: $euiFontSizeS; // In case the label is just white space
       position: relative;
       z-index: 2;
       cursor: pointer;

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -82,6 +82,7 @@
       z-index: 1; /* 1 */
       margin: 0; /* 1 */
       cursor: pointer;
+      outline: none;
     }
   }
 }

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -3,6 +3,10 @@
 
   &:not(.euiRadio--noLabel) .euiRadio__input {
     @include euiScreenReaderOnly;
+    // Because this input is still focusable, it causes the screen-reader outline
+    // to extend to the position of the screen-reader element.
+    // So we must position it against it's own bounds.
+    left: 0;
   }
 
   .euiRadio__input {
@@ -11,7 +15,7 @@
       padding-left: ($euiRadioSize * 1.5);
       line-height: $euiSizeL;
       font-size: $euiFontSizeS;
-      min-height: $euiFontSizeS; // In case the label is just white space
+      min-height: $euiRadioSize; // In case the label is just white space
       position: relative;
       z-index: 2;
       cursor: pointer;
@@ -52,8 +56,7 @@
       }
     }
 
-    &:focus,
-    &:active:not(:disabled) {
+    &:focus {
       + .euiRadio__circle {
         @include euiCustomControlFocused;
       }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -137,6 +137,7 @@
 
     .euiCheckbox__label {
       font-size: fontSizeToRemOrEm($baseFontSize, $sizingMethod);
+      min-height: fontSizeToRemOrEm($baseFontSize, $sizingMethod); // In case the label is just white space
       padding-left: marginToRemOrEm($baseLineHeightMultiplier * 3, $baseFontSize, $sizingMethod);
       line-height: $baseLineHeightMultiplier * 3 / $baseFontSize;
     }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -139,7 +139,7 @@
       font-size: fontSizeToRemOrEm($baseFontSize, $sizingMethod);
       min-height: fontSizeToRemOrEm($baseFontSize, $sizingMethod); // In case the label is just white space
       padding-left: marginToRemOrEm($baseLineHeightMultiplier * 3, $baseFontSize, $sizingMethod);
-      line-height: $baseLineHeightMultiplier * 3 / $baseFontSize;
+      line-height: $euiCheckBoxSize;
     }
 
     .euiCheckbox + *:not(.euiCheckbox) {


### PR DESCRIPTION
And removes the flash of focus ring in Safari (active state) and screen-reader outline encompassing the off-screen element.