### PR TITLE
Docs & Comments & Updates styles for EuiScreenReaderOnly

### DIFF
--- a/src-docs/src/views/accessibility/accessibility_example.js
+++ b/src-docs/src/views/accessibility/accessibility_example.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { renderToHtml } from '../../services';
-
 import { GuideSectionTypes } from '../../components';
 
 import {
@@ -10,32 +8,25 @@ import {
   EuiLink,
   EuiSkipLink,
   EuiScreenReaderOnly,
+  EuiSpacer,
 } from '../../../../src/components';
 
 import ScreenReaderOnly from './screen_reader';
+import ScreenReaderFocus from './screen_reader_focus';
+import ScreenReaderButton from './screen_reader_button';
 import SkipLink from './skip_link';
 
-const screenReaderOnlyHtml = renderToHtml(ScreenReaderOnly);
 const screenReaderOnlySource = require('!!raw-loader!./screen_reader');
-const screenReaderOnlySnippet = [
-  `<EuiScreenReaderOnly>
-  <!-- visually hidden content -->
-</EuiScreenReaderOnly>
-`,
-  `<EuiScreenReaderOnly showOnFocus>
-  <!-- visually hidden content, displayed on focus -->
-</EuiScreenReaderOnly>
-`,
-];
+const screenReaderFocusSource = require('!!raw-loader!./screen_reader_focus');
+const screenReaderButtonSource = require('!!raw-loader!./screen_reader_button');
 
-const skipLinkHtml = renderToHtml(SkipLink);
 const skipLinkSource = require('!!raw-loader!./skip_link');
 const skipLinkSnippet = [
-  `<EuiSkipLink destinationId="myAnchorId">
+  `<EuiSkipLink destinationId={myAnchorId}>
   Skip to content
 </EuiSkipLink>
 `,
-  `<EuiSkipLink destinationId="myAnchorId" position="fixed">
+  `<EuiSkipLink destinationId={myAnchorId} position="fixed">
   Skip to main content
 </EuiSkipLink>
 `,
@@ -51,19 +42,15 @@ export const AccessibilityExample = {
           type: GuideSectionTypes.JS,
           code: screenReaderOnlySource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: screenReaderOnlyHtml,
-        },
       ],
       text: (
-        <div>
+        <>
           <p>
-            Use the <strong>EuiScreenReaderOnly</strong> component to visually
-            hide elements while still allowing them to be read by screen
-            readers. In certain cases, you may want to use the{' '}
-            <EuiCode>showOnFocus</EuiCode> prop to display screen reader-only
-            content when in focus.
+            Using <strong>EuiScreenReaderOnly</strong> hides the wrapped element
+            from the page, but keeps it accessible for screen readers to provide
+            more context. It should be used primarily to mask{' '}
+            <strong>text</strong> and requires the child to be a single React
+            element for cloning.
           </p>
           <EuiCallOut
             color="warning"
@@ -75,21 +62,93 @@ export const AccessibilityExample = {
               provides functionality or interactivity) is important enough to
               provide to screen reader users, it should probably be made
               available to all users.&quot;{' '}
-              <EuiLink
-                href="http://webaim.org/techniques/css/invisiblecontent/"
-                external
-              >
+              <EuiLink href="http://webaim.org/techniques/css/invisiblecontent/">
                 Learn more about invisible content
               </EuiLink>
             </p>
           </EuiCallOut>
-        </div>
+          <EuiSpacer />
+          <p>
+            <em>
+              Using a screen reader, verify that there is a second paragraph.
+            </em>
+          </p>
+        </>
       ),
       props: {
         EuiScreenReaderOnly,
       },
-      snippet: screenReaderOnlySnippet,
+      snippet: `<EuiScreenReaderOnly>
+  <!-- visually hidden content -->
+</EuiScreenReaderOnly>`,
       demo: <ScreenReaderOnly />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: screenReaderButtonSource,
+        },
+      ],
+      text: (
+        <>
+          <h3>Within a button</h3>
+          <p>
+            If the screen reader content is <strong>contained within</strong> a
+            focusable element, you should consider adding{' '}
+            <EuiCode language="scss">{'position: relative;'}</EuiCode> to the
+            focusable element. This will fix any screen reader focus rings to
+            stay within the bounds of the focusable element.
+          </p>
+          <p>
+            <em>
+              Using a screen reader, tab through the following example with your
+              keyboard to verify the focus outline and screen reader text.
+            </em>
+          </p>
+        </>
+      ),
+      props: {
+        EuiScreenReaderOnly,
+      },
+      snippet: `<button style={{ position: 'relative' }}>
+  Button text
+  <EuiScreenReaderOnly>
+    <!-- visually hidden content -->
+  </EuiScreenReaderOnly>
+</button>`,
+      demo: <ScreenReaderButton />,
+    },
+    {
+      source: [
+        {
+          type: GuideSectionTypes.JS,
+          code: screenReaderFocusSource,
+        },
+      ],
+      text: (
+        <>
+          <h3>Showing on focus</h3>
+          <p>
+            If the wrapped element <strong>is focusable</strong>, you must use
+            the <EuiCode>showOnFocus</EuiCode> prop to visibly show the element
+            to all users when focused.
+          </p>
+          <p>
+            <em>
+              Tab through the following example with your keyboard to verify the
+              element is visible on focus.
+            </em>
+          </p>
+        </>
+      ),
+      props: {
+        EuiScreenReaderOnly,
+      },
+      snippet: `<EuiScreenReaderOnly showOnFocus>
+  <!-- visually hidden content, displayed on focus -->
+</EuiScreenReaderOnly>`,
+      demo: <ScreenReaderFocus />,
     },
     {
       title: 'Skip link',
@@ -98,17 +157,24 @@ export const AccessibilityExample = {
           type: GuideSectionTypes.JS,
           code: skipLinkSource,
         },
-        {
-          type: GuideSectionTypes.HTML,
-          code: skipLinkHtml,
-        },
       ],
       text: (
-        <p>
-          The <strong>EuiSkipLink</strong> component allows users to bypass
-          navigation, or ornamental elements, and quickly reach the main content
-          of the page.
-        </p>
+        <>
+          <p>
+            The <strong>EuiSkipLink</strong> component allows users to bypass
+            navigation, or ornamental elements, and quickly reach the main
+            content of the page. It requires a <EuiCode>destinationId</EuiCode>{' '}
+            which should match the <EuiCode>id</EuiCode> of your main content.
+            You can also change the <EuiCode>position</EuiCode> to{' '}
+            <EuiCode>fixed</EuiCode>.
+          </p>
+          <p>
+            <em>
+              Tab through the following section to verify the{' '}
+              <strong>Skip to content</strong> button is visible on focus.
+            </em>
+          </p>
+        </>
       ),
       props: { EuiSkipLink },
       snippet: skipLinkSnippet,

--- a/src-docs/src/views/accessibility/screen_reader.tsx
+++ b/src-docs/src/views/accessibility/screen_reader.tsx
@@ -1,51 +1,16 @@
 import React from 'react';
 
-import { EuiScreenReaderOnly } from '../../../../src/components/accessibility/screen_reader';
-import { EuiCallOut } from '../../../../src/components/call_out';
-import { EuiText } from '../../../../src/components/text';
-import { EuiTitle } from '../../../../src/components/title';
-import { EuiLink } from '../../../../src/components/link';
+import { EuiScreenReaderOnly, EuiText } from '../../../../src/components';
 
 export default () => (
-  <div>
-    <EuiText>
-      <EuiTitle size="xxs">
-        <h3>Visually hide content</h3>
-      </EuiTitle>
+  <EuiText>
+    <p>This is the first paragraph. It is visible to all.</p>
+    <EuiScreenReaderOnly>
       <p>
-        <em>
-          Use a screenreader to verify that there is a second paragraph in this
-          example:
-        </em>
+        This is the second paragraph. It is hidden for sighted users but visible
+        to screen readers.
       </p>
-      <p>This is the first paragraph. It is visible to all.</p>
-      <EuiScreenReaderOnly>
-        <p>
-          This is the second paragraph. It is hidden for sighted users but
-          visible to screen readers.
-        </p>
-      </EuiScreenReaderOnly>
-      <p>This is the third paragraph. It is visible to all.</p>
-      <EuiTitle size="xxs">
-        <h4>Show on focus</h4>
-      </EuiTitle>
-      <p>
-        <em>
-          Tab through this section with your keyboard to display a &lsquo;Skip
-          navigation&rsquo; link:
-        </em>
-      </p>
-      <p>
-        This link is visible to all on focus:{' '}
-        <EuiScreenReaderOnly showOnFocus>
-          <EuiLink href="#">Skip navigation</EuiLink>
-        </EuiScreenReaderOnly>
-      </p>
-      <EuiCallOut
-        size="s"
-        title="For a fully styled &lsquo;Skip to main content&rsquo; solution, see the EuiSkipLink component in the next section."
-        iconType="iInCircle"
-      />
-    </EuiText>
-  </div>
+    </EuiScreenReaderOnly>
+    <p>This is the third paragraph. It is visible to all.</p>
+  </EuiText>
 );

--- a/src-docs/src/views/accessibility/screen_reader_button.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_button.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import {
+  EuiScreenReaderOnly,
+  EuiText,
+  EuiLink,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiText>
+    <p>
+      Without relative position:{' '}
+      <EuiLink href="#/utilities/accessibility">
+        Link text{' '}
+        <EuiScreenReaderOnly>
+          <span>has screen reader text</span>
+        </EuiScreenReaderOnly>
+      </EuiLink>
+    </p>
+    <p>
+      With releative position:{' '}
+      <EuiLink
+        style={{ position: 'relative' }}
+        href="#/utilities/accessibility"
+      >
+        Link text{' '}
+        <EuiScreenReaderOnly>
+          <span>has screen reader text</span>
+        </EuiScreenReaderOnly>
+      </EuiLink>
+    </p>
+  </EuiText>
+);

--- a/src-docs/src/views/accessibility/screen_reader_focus.tsx
+++ b/src-docs/src/views/accessibility/screen_reader_focus.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import {
+  EuiScreenReaderOnly,
+  EuiText,
+  EuiLink,
+} from '../../../../src/components';
+
+export default () => (
+  <EuiText>
+    <p>
+      This link is visible to all on focus:{' '}
+      <EuiScreenReaderOnly showOnFocus>
+        <EuiLink href="#/utilities/accessibility">Link text</EuiLink>
+      </EuiScreenReaderOnly>
+    </p>
+  </EuiText>
+);

--- a/src-docs/src/views/accessibility/skip_link.tsx
+++ b/src-docs/src/views/accessibility/skip_link.tsx
@@ -3,7 +3,6 @@ import React, { useState } from 'react';
 import {
   EuiSkipLink,
   EuiCallOut,
-  EuiText,
   EuiSpacer,
   EuiSwitch,
 } from '../../../../src/components';
@@ -13,25 +12,6 @@ export default () => {
 
   return (
     <>
-      <EuiText>
-        {isFixed ? (
-          <p>
-            <em>
-              Tab through this section and a fixed{' '}
-              <strong>Skip to main content </strong> link will appear atop this
-              page.
-            </em>
-          </p>
-        ) : (
-          <p>
-            <em>
-              Tab through this section and a <strong>Skip to content</strong>{' '}
-              link will appear below.
-            </em>
-          </p>
-        )}
-      </EuiText>
-      <EuiSpacer />
       <EuiSwitch
         label="Fix link to top of screen"
         checked={isFixed}

--- a/src/components/form/checkbox/_checkbox.scss
+++ b/src/components/form/checkbox/_checkbox.scss
@@ -1,11 +1,22 @@
+/**
+  * 1. Float above the visual radio and match its dimension, so that when users try to click it
+  *    they actually click this input.
+  */
+
 .euiCheckbox {
   position: relative;
 
-  &:not(.euiCheckbox--noLabel) .euiCheckbox__input {
-    @include euiScreenReaderOnly;
-  }
+  // Set a top offset for the real input and faux input to align better with the text
+  $topOffset: (($euiSizeL - $euiCheckBoxSize) / 2) - 1px;
 
   .euiCheckbox__input {
+    @include size($euiCheckBoxSize);
+    top: $topOffset;
+    cursor: pointer;
+    position: absolute; /* 1 */
+    opacity: 0; /* 1 */
+    z-index: 1; /* 1 */
+
     ~ .euiCheckbox__label {
       display: inline-block;
       padding-left: ($euiCheckBoxSize * 1.5);
@@ -18,11 +29,10 @@
 
     + .euiCheckbox__square {
       @include euiCustomControl($type: 'square', $size: $euiCheckBoxSize);
-
       display: inline-block;
       position: absolute;
       left: 0;
-      top: (($euiSizeL - $euiCheckBoxSize) / 2) - 1px;
+      top: $topOffset;
     }
 
     &:checked {
@@ -63,36 +73,25 @@
       }
     }
 
-    &:focus,
-    &:active:not(:disabled) {
+    &:focus {
       + .euiCheckbox__square {
         @include euiCustomControlFocused;
       }
     }
   }
 
-  /**
-   * 1. Float above the visual radio and match its dimension, so that when users try to click it
-   *    they actually click this input.
-   */
-
   &.euiCheckbox--inList,
   &.euiCheckbox--noLabel {
     min-height: $euiCheckBoxSize;
     min-width: $euiCheckBoxSize;
 
+    .euiCheckbox__input,
     .euiCheckbox__square {
       top: 0;
     }
 
     .euiCheckbox__input {
-      @include size($euiCheckBoxSize); /* 1 */
-
-      position: absolute; /* 1 */
-      opacity: 0; /* 1 */
-      z-index: 1; /* 1 */
-      margin: 0; /* 1 */
-      cursor: pointer;
+      margin: 0;
     }
   }
 }

--- a/src/components/form/radio/_radio.scss
+++ b/src/components/form/radio/_radio.scss
@@ -1,11 +1,22 @@
+/**
+  * 1. Float above the visual radio and match its dimension, so that when users try to click it
+  *    they actually click this input.
+  */
+
 .euiRadio {
   position: relative;
 
-  &:not(.euiRadio--noLabel) .euiRadio__input {
-    @include euiScreenReaderOnly;
-  }
+  // Set a top offset for the real input and faux input to align better with the text
+  $topOffset: (($euiSizeL - $euiRadioSize) / 2) - 1px;
 
   .euiRadio__input {
+    @include size($euiRadioSize);
+    top: $topOffset;
+    cursor: pointer;
+    position: absolute; /* 1 */
+    opacity: 0; /* 1 */
+    z-index: 1; /* 1 */
+
     ~ .euiRadio__label {
       display: inline-block;
       padding-left: ($euiRadioSize * 1.5);
@@ -22,7 +33,7 @@
       display: inline-block;
       position: absolute;
       left: 0;
-      top: (($euiSizeL - $euiRadioSize) / 2) - 1px;
+      top: $topOffset;
     }
 
     &:checked {
@@ -51,36 +62,25 @@
       }
     }
 
-    &:focus,
-    &:active:not(:disabled) {
+    &:focus {
       + .euiRadio__circle {
         @include euiCustomControlFocused;
       }
     }
   }
 
-  /**
-   * 1. Float above the visual radio and match its dimension, so that when users try to click it
-   *    they actually click this input.
-   */
-
   &.euiRadio--inList,
   &.euiRadio--noLabel {
     min-height: $euiRadioSize;
     min-width: $euiRadioSize;
 
+    .euiRadio__input,
     .euiRadio__circle {
       top: 0;
     }
 
     .euiRadio__input {
-      @include size($euiRadioSize); /* 1 */
-
-      position: absolute; /* 1 */
-      opacity: 0; /* 1 */
-      z-index: 1; /* 1 */
-      margin: 0; /* 1 */
-      cursor: pointer;
+      margin: 0;
     }
   }
 }

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -1,6 +1,11 @@
 .euiLink {
   @include euiLink;
 
+  &[target='_blank'] {
+    // Make the screen reader only text positioned relatively against the link itself
+    position: relative;
+  }
+
   .euiLink__externalIcon {
     margin-left: $euiSizeXS;
   }

--- a/src/global_styling/mixins/_helpers.scss
+++ b/src/global_styling/mixins/_helpers.scss
@@ -106,18 +106,24 @@
 }
 
 // Hiding elements offscreen to only be read by screen reader
-// NOTE: Hidden absolute positioning can cause issues with scrolling/overflow.
-// `clip` and `left` (for Chromium browsers) are needed to prevent these issues -
-// @see https://github.com/elastic/eui/pull/5130 for more info
+// See https://github.com/elastic/eui/pull/5130 and https://github.com/elastic/eui/pull/5152 for more info
 @mixin euiScreenReaderOnly {
+  // Take the element out of the layout
   position: absolute;
-  left: -10000px;
+  // Keep it vertically inline
   top: auto;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
+  // Chrome requires a left value
+  left: 0;
+  // The element must have a size (for some screen readers)
   width: 1px;
   height: 1px;
+  // But reduce the visible size to nothing
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  // And ensure no overflows occur
   overflow: hidden;
+  // Chrome requires the negative margin to not cause overflows of parent containers
+  margin: -1px;
 }
 
 // Specifically target IE11, but not Edge.


### PR DESCRIPTION
**tl;dr**

This still fixes nothing but the original issue of overflowing content in tables. At least the caveats are documented and we can take a few extra steps down the line to rectify some of them on our side.

---

# Docs

I re-wrote a lot of the Screen Reader Only docs to mention some of the nuances.

# Comments

I updated the mixin and added comments, more line-by-line, detailing why each was important.

# Updated styles

Based on your advice to just remove the mixin from the checkboxes and radios, I've adjusted those styles. 

Here are some screenshots of the placement of the input in all 3 browsers, Chrome - Safari - Firefox (which is blurry cuz i use it to test non-retina stuff). 

![image](https://user-images.githubusercontent.com/549577/132597546-96ef84f1-cceb-41db-96a2-7206ebfb9bfb.png)
![image](https://user-images.githubusercontent.com/549577/132597550-54991f19-8a43-4dc5-99e7-eeed9781ccfb.png)


# EuiLink

I also added a style specifically to EuiLink that makes is `position: relative` if it contains that screen reader text which is only there if `target="_blank"`. This is just an example really, but we could/should comb through usages that we know exist inside a focusable element.

![image](https://user-images.githubusercontent.com/549577/132597643-9ee13ed1-b673-4d2b-8e93-911b62b4e4f5.png)

