### PR TITLE
[EuiSearchBar] Allow more special characters

### DIFF
--- a/src/components/search_bar/query/default_syntax.ts
+++ b/src/components/search_bar/query/default_syntax.ts
@@ -169,7 +169,7 @@ word
 
 wordChar
   = alnum
-  / [-_*:/]
+  / [^:()"]
   / escapedChar
   / extendedGlyph
 


### PR DESCRIPTION
(This PR is for archival purposes only)

The code diff allows every character that isn't one needed for EQL syntax. Was spiked out during https://github.com/elastic/eui/issues/7160